### PR TITLE
Removal of unnecessary methods and public constructors

### DIFF
--- a/sdk/core/azure-core-http-httpurlconnection/src/main/java/com/azure/core/http/httpurlconnection/HttpUrlConnectionClient.java
+++ b/sdk/core/azure-core-http-httpurlconnection/src/main/java/com/azure/core/http/httpurlconnection/HttpUrlConnectionClient.java
@@ -10,27 +10,6 @@ import java.nio.charset.StandardCharsets;
 
 public class HttpUrlConnectionClient implements HttpClient {
 
-    private HttpRequest request;
-    private HttpURLConnection connection;
-
-    // Default constructor
-    public HttpUrlConnectionClient(){}
-
-    // Constructor initializing with a specific request
-    public HttpUrlConnectionClient(HttpRequest request) {
-        this.setRequest(request);
-    }
-
-    // Setter for HttpRequest
-    public void setRequest(HttpRequest request) {
-        this.request = request;
-    }
-
-    // Asynchronous send method returning a Mono of HttpResponse
-    public Mono<HttpResponse> send() {
-        return sendAsync(this.request, Context.NONE);
-    }
-
     // Asynchronous send method returning a Mono of HttpResponse
     @Override
     public Mono<HttpResponse> send(HttpRequest httpRequest) {

--- a/sdk/core/azure-core-http-httpurlconnection/src/main/java/com/azure/core/http/httpurlconnection/HttpUrlConnectionClientBuilder.java
+++ b/sdk/core/azure-core-http-httpurlconnection/src/main/java/com/azure/core/http/httpurlconnection/HttpUrlConnectionClientBuilder.java
@@ -11,9 +11,4 @@ public class HttpUrlConnectionClientBuilder {
         HttpUrlConnectionClient client = new HttpUrlConnectionClient();
         return client;
     }
-
-    public HttpClient build(HttpRequest request) {
-        HttpUrlConnectionClient client = new HttpUrlConnectionClient(request);
-        return client;
-    }
 }


### PR DESCRIPTION
- Removed public constructors for HttpUrlConnectionClient. 
- Removed the 'connection' and 'request' fields in HttpUrlConnectionClient to ensure statelessness. 
- Removed related functions for setting the request field in HttpUrlConnectionClient and the builder. 
- Removed parameterless send functions in HttpUrlConnectionClient.
